### PR TITLE
ci(buildkite): prevent log truncation and fix post-command hook

### DIFF
--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -1,7 +1,42 @@
 #!/usr/bin/env bash
 set -u
 
-if [[ "${BUILDKITE_LABEL}" == ":docker: Build and Deploy Image" ]]; then
+if [[ "${BUILDKITE_LABEL}" == ":docker: Build and Deploy" ]]; then
+  if [[ ${BUILDKITE_BRANCH} == "master" ]] && [[ ${BUILDKITE_PULL_REQUEST} == "false" ]]; then
+    echo "--- :docker: Removing tags for deleted branches"
+    anontoken=$(curl -fsL --retry 3 'https://auth.docker.io/token?service=registry.docker.io&scope=repository:authelia/base:pull' | jq -r .token)
+    authtoken=$(curl -fs --retry 3 -H "Content-Type: application/json" -X "POST" -d '{"username": "'${DOCKER_USERNAME}'", "password": "'${DOCKER_PASSWORD}'"}' https://hub.docker.com/v2/users/login/ | jq -r .token)
+    dockerbranchtags=$(curl -fsL --retry 3 -H "Authorization: Bearer ${anontoken}" https://registry-1.docker.io/v2/authelia/base/tags/list | jq -r '.tags[] | select(startswith("PR") | not)' | sed -r '/^(latest|master|BK([[:digit:]]+)|([[:digit:]]+)\.?([[:digit:]]+)?\.?([[:digit:]]+)?)$/d' | sort)
+    githubbranches=$(curl -fs --retry 3 https://api.github.com/repos/authelia/baseimage/branches | jq -r '.[].name' | sort)
+
+    for BRANCH_TAG in $(comm -23 <(echo "${dockerbranchtags}") <(echo "${githubbranches}")); do
+      echo "Removing tag ${BRANCH_TAG} from docker.io"
+      curl -fsL --retry 3 -o /dev/null -X "DELETE" -H "Authorization: JWT ${authtoken}" https://hub.docker.com/v2/repositories/authelia/base/tags/${BRANCH_TAG}/
+      for i in {1..5}; do
+        for GHCR_VERSION in $(curl -fsL --retry 3 -H "Authorization: Bearer ${GHCR_PASSWORD}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/orgs/authelia/packages/container/base/versions?page=${i}&per_page=100" | jq -j --arg tag ${BRANCH_TAG} '.[] | select(.metadata.container.tags[] | contains($tag)) | .metadata.container.tags[], ",", .id, "\n"'); do
+          IFS=',' read -a TAGID <<< ${GHCR_VERSION}
+          echo "Removing tag ${TAGID[0]} with id ${TAGID[1]} from ghcr.io"
+          curl -fsL --retry 3 -o /dev/null -X "DELETE" -H "Authorization: Bearer ${GHCR_PASSWORD}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/orgs/authelia/packages/container/base/versions/${TAGID[1]}
+        done
+      done
+    done
+
+    echo "--- :docker: Removing tags for merged or closed pull requests"
+    dockerprtags=$(curl -fsL --retry 3 -H "Authorization: Bearer ${anontoken}" https://registry-1.docker.io/v2/authelia/base/tags/list | jq -r '.tags[] | select(startswith("PR"))' | sort)
+    githubprs=$(curl -fs --retry 3 https://api.github.com/repos/authelia/baseimage/pulls | jq -r '.[].number' | sed -e 's/^/PR/' | sort)
+    for PR_TAG in $(comm -23 <(echo "${dockerprtags}") <(echo "${githubprs}")); do
+      echo "Removing tag ${PR_TAG} from docker.io"
+      curl -fsL --retry 3 -o /dev/null -X "DELETE" -H "Authorization: JWT ${authtoken}" https://hub.docker.com/v2/repositories/authelia/base/tags/${PR_TAG}/
+      for i in {1..5}; do
+        for GHCR_VERSION in $(curl -fsL --retry 3 -H "Authorization: Bearer ${GHCR_PASSWORD}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/orgs/authelia/packages/container/base/versions?page=${i}&per_page=100" | jq -j --arg tag ${PR_TAG} '.[] | select(.metadata.container.tags[] | contains($tag)) | .metadata.container.tags[], ",", .id, "\n"'); do
+          IFS=',' read -a TAGID <<< ${GHCR_VERSION}
+          echo "Removing tag ${TAGID[0]} with id ${TAGID[1]} from ghcr.io"
+          curl -fsL --retry 3 -o /dev/null -X "DELETE" -H "Authorization: Bearer ${GHCR_PASSWORD}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/orgs/authelia/packages/container/base/versions/${TAGID[1]}
+        done
+      done
+    done
+  fi
+
   echo "--- :docker: Removing tags for deleted branches"
   anontoken=$(curl -fsL --retry 3 'https://auth.docker.io/token?service=registry.docker.io&scope=repository:authelia/base:pull' | jq -r .token)
   authtoken=$(curl -fs --retry 3 -H "Content-Type: application/json" -X "POST" -d '{"username": "'${DOCKER_USERNAME}'", "password": "'${DOCKER_PASSWORD}'"}' https://hub.docker.com/v2/users/login/ | jq -r .token)

--- a/.buildkite/hooks/post-command
+++ b/.buildkite/hooks/post-command
@@ -37,39 +37,6 @@ if [[ "${BUILDKITE_LABEL}" == ":docker: Build and Deploy" ]]; then
     done
   fi
 
-  echo "--- :docker: Removing tags for deleted branches"
-  anontoken=$(curl -fsL --retry 3 'https://auth.docker.io/token?service=registry.docker.io&scope=repository:authelia/base:pull' | jq -r .token)
-  authtoken=$(curl -fs --retry 3 -H "Content-Type: application/json" -X "POST" -d '{"username": "'${DOCKER_USERNAME}'", "password": "'${DOCKER_PASSWORD}'"}' https://hub.docker.com/v2/users/login/ | jq -r .token)
-  dockerbranchtags=$(curl -fsL --retry 3 -H "Authorization: Bearer ${anontoken}" https://registry-1.docker.io/v2/authelia/base/tags/list | jq -r '.tags[] | select(startswith("PR") | not)' | sed -r '/^(latest|master|BK([[:digit:]]+)|([[:digit:]]+)\.?([[:digit:]]+)?\.?([[:digit:]]+)?)$/d' | sort)
-  githubbranches=$(curl -fs --retry 3 https://api.github.com/repos/authelia/baseimage/branches | jq -r '.[].name' | sort)
-
-  for BRANCH_TAG in $(comm -23 <(echo "${dockerbranchtags}") <(echo "${githubbranches}")); do
-    echo "Removing tag ${BRANCH_TAG} from docker.io"
-    curl -fsL --retry 3 -o /dev/null -X "DELETE" -H "Authorization: JWT ${authtoken}" https://hub.docker.com/v2/repositories/authelia/base/tags/${BRANCH_TAG}/
-    for i in {1..5}; do
-      for GHCR_VERSION in $(curl -fsL --retry 3 -H "Authorization: Bearer ${GHCR_PASSWORD}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/orgs/authelia/packages/container/base/versions?page=${i}&per_page=100" | jq -j --arg tag ${BRANCH_TAG} '.[] | select(.metadata.container.tags[] | contains($tag)) | .metadata.container.tags[], ",", .id, "\n"'); do
-        IFS=',' read -a TAGID <<< ${GHCR_VERSION}
-        echo "Removing tag ${TAGID[0]} with id ${TAGID[1]} from ghcr.io"
-        curl -fsL --retry 3 -o /dev/null -X "DELETE" -H "Authorization: Bearer ${GHCR_PASSWORD}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/orgs/authelia/packages/container/base/versions/${TAGID[1]}
-      done
-    done
-  done
-
-  echo "--- :docker: Removing tags for merged or closed pull requests"
-  dockerprtags=$(curl -fsL --retry 3 -H "Authorization: Bearer ${anontoken}" https://registry-1.docker.io/v2/authelia/base/tags/list | jq -r '.tags[] | select(startswith("PR"))' | sort)
-  githubprs=$(curl -fs --retry 3 https://api.github.com/repos/authelia/baseimage/pulls | jq -r '.[].number' | sed -e 's/^/PR/' | sort)
-  for PR_TAG in $(comm -23 <(echo "${dockerprtags}") <(echo "${githubprs}")); do
-    echo "Removing tag ${PR_TAG} from docker.io"
-    curl -fsL --retry 3 -o /dev/null -X "DELETE" -H "Authorization: JWT ${authtoken}" https://hub.docker.com/v2/repositories/authelia/base/tags/${PR_TAG}/
-    for i in {1..5}; do
-      for GHCR_VERSION in $(curl -fsL --retry 3 -H "Authorization: Bearer ${GHCR_PASSWORD}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/orgs/authelia/packages/container/base/versions?page=${i}&per_page=100" | jq -j --arg tag ${PR_TAG} '.[] | select(.metadata.container.tags[] | contains($tag)) | .metadata.container.tags[], ",", .id, "\n"'); do
-        IFS=',' read -a TAGID <<< ${GHCR_VERSION}
-        echo "Removing tag ${TAGID[0]} with id ${TAGID[1]} from ghcr.io"
-        curl -fsL --retry 3 -o /dev/null -X "DELETE" -H "Authorization: Bearer ${GHCR_PASSWORD}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/orgs/authelia/packages/container/base/versions/${TAGID[1]}
-      done
-    done
-  done
-
   docker logout docker.io
   docker logout ghcr.io
 fi

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -23,7 +23,7 @@ for REGISTRY in ${REGISTRIES}; do for TAG in ${TAGS}; do BUILDTAGS+="-t ${REGIST
 cat << EOF
 steps:
   - label: ":docker: Build and Deploy"
-    command: "docker build ${BUILDTAGS::-1} --label org.opencontainers.image.source=https://github.com/${REPOSITORY} --platform linux/amd64,linux/arm/v7,linux/arm64 --provenance mode=max,reproducible=true --sbom true --builder buildx --pull --push ."
+    command: "docker build ${BUILDTAGS::-1} --label org.opencontainers.image.source=https://github.com/${REPOSITORY} --platform linux/amd64,linux/arm/v7,linux/arm64 --provenance mode=max,reproducible=true --sbom true --builder buildx --progress plain --pull --push ."
 EOF
 if [[ "${BUILDKITE_BRANCH}" == "master" ]]; then
 cat << EOF


### PR DESCRIPTION
Use plain progress to prevent log truncation in Buildkite.
Update `post-command` hook to use the correct label. 