### PR TITLE
refactor: swap to su-exec-musl-static

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN \
     exec /root-fs/bin/busybox --install /root-fs/bin
 
 RUN  \
-    wget -qO /root-fs/sbin/su-exec "https://github.com/songdongsheng/su-exec/releases/download/${SUEXEC_RELEASE}/su-exec-glibc-shared" && chmod +x /root-fs/sbin/su-exec
+    wget -qO /root-fs/sbin/su-exec "https://github.com/songdongsheng/su-exec/releases/download/${SUEXEC_RELEASE}/su-exec-musl-static" && chmod +x /root-fs/sbin/su-exec
 
 FROM scratch
 

--- a/README.md
+++ b/README.md
@@ -22,5 +22,6 @@ This container includes the bare minimum packages for Authelia to function in a 
 * wget
 
 ## Version
+- **28/10/2024:** Swap to musl-static variant of su-exec for multi-arch support
 - **16/10/2024:** Add Provenance and SBOM attestations
 - **15/10/2024:** Initial release


### PR DESCRIPTION
Utilise the static musl binary of su-exec until a point that upstream can provide glibc architecture specific releases.