### PR TITLE
fix: swap to ncopa su-exec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM buildpack-deps:24.04 AS chisel
 
 ARG CHISEL_RELEASE="1.0.0"
-ARG SUEXEC_RELEASE="1.3"
+ARG SUEXEC_RELEASE="0.2"
 ARG TARGETARCH
 
 WORKDIR /root-fs
@@ -16,7 +16,7 @@ RUN \
     exec /root-fs/bin/busybox --install /root-fs/bin
 
 RUN  \
-    wget -qO /root-fs/sbin/su-exec "https://github.com/songdongsheng/su-exec/releases/download/${SUEXEC_RELEASE}/su-exec-musl-static" && chmod +x /root-fs/sbin/su-exec
+    wget -qO - "https://github.com/ncopa/su-exec/archive/refs/tags/v${SUEXEC_RELEASE}.tar.gz" | tar -xz -C /tmp && make -C /tmp/su-exec-${SUEXEC_RELEASE} && mv /tmp/su-exec-${SUEXEC_RELEASE}/su-exec /root-fs/sbin/su-exec
 
 FROM scratch
 


### PR DESCRIPTION
Utilise the same su-exec version that was bundled in our original alpine base images, as this allows running as users that aren't explicitly defined in the environment.

Fixes https://github.com/authelia/authelia/issues/8938.