### PR TITLE
fix: busybox 1.37.0 cve

### DIFF
--- a/.github/probot.js
+++ b/.github/probot.js
@@ -1,39 +1,29 @@
+const excludedBranchPrefixes =
+    /^(docs|all-contributors\/|dependabot\/|renovate\/)/;
+
 // PR commentary for Authelia branch based contributions
-on('pull_request.opened')
-    .filter(
-        context =>
-            context.payload.pull_request.head.label.slice(0, 9) === 'authelia:'
+on("pull_request.opened")
+    .filter((context) =>
+        context.payload.pull_request.head.label.startsWith("authelia:"),
     )
-    .filter(
-        context =>
-            context.payload.pull_request.head.ref.slice(0, 17) !== 'all-contributors/'
-    )
-    .filter(
-        context =>
-            context.payload.pull_request.head.ref.slice(0, 11) !== 'dependabot/'
-    )
-    .filter(
-        context =>
-            context.payload.pull_request.head.ref.slice(0, 9) !== 'renovate/'
-    )
+    .filter((context) => {
+        return !excludedBranchPrefixes.test(context.payload.pull_request.head.ref);
+    })
+    .filter((context) => !context.payload.pull_request.title.startsWith("docs"))
     .comment(`## Artifacts
-These changes are published for testing on DockerHub and GitHub Container Registry.
+These changes are published for testing on Buildkite, DockerHub and GitHub Container Registry.
 
 ### Docker Container
 * \`docker pull authelia/base:{{ pull_request.head.ref }}\`
-* \`docker pull ghcr.io/authelia/base:{{ pull_request.head.ref }}\``)
+* \`docker pull ghcr.io/authelia/base:{{ pull_request.head.ref }}\``);
 
 // PR commentary for third party based contributions
-on('pull_request.opened')
-    .filter(
-        context =>
-            context.payload.pull_request.head.label.slice(0, 9) !== 'authelia:'
-    )
-    .comment(`Thanks for choosing to contribute @{{ pull_request.user.login }}.
-
-## Artifacts
-These changes once approved by a team member will be published for testing on DockerHub and GitHub Container Registry.
+on("pull_request.opened").filter((context) =>
+    !context.payload.pull_request.head.label.startsWith("authelia:"),
+)
+    .comment(`## Artifacts
+These changes once approved by a team member will be published for testing on Buildkite, DockerHub and GitHub Container Registry.
 
 ### Docker Container
 * \`docker pull authelia/base:PR{{ pull_request.number }}\`
-* \`docker pull ghcr.io/authelia/base:PR{{ pull_request.number }}\``)
+* \`docker pull ghcr.io/authelia/base:PR{{ pull_request.number }}\``);

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,47 @@
 FROM buildpack-deps:24.04 AS chisel
 
-ARG CHISEL_RELEASE="1.0.0"
+ARG BUSYBOX_RELEASE=1.37.0
+ARG BUSYBOX_REV=4
+ARG CHISEL_RELEASE="1.2.0"
 ARG SUEXEC_RELEASE="0.2"
 ARG TARGETARCH
 
 WORKDIR /root-fs
 
-RUN \
+RUN <<EOF
     wget -qO - "https://github.com/canonical/chisel/releases/download/v${CHISEL_RELEASE}/chisel_v${CHISEL_RELEASE}_linux_${TARGETARCH}.tar.gz" | tar -xz --no-same-owner -C /usr/local/bin chisel
 
-RUN \
     chisel cut --release ubuntu-24.04 --root /root-fs \
-    base-files_base base-files_release-info base-passwd_data busybox_bins \
+    base-files_base base-files_release-info base-passwd_data \
     ca-certificates_data libc-bin_nsswitch tzdata_zoneinfo wget_bins && \
-    exec /root-fs/bin/busybox --install /root-fs/bin
 
-RUN  \
+    cd /tmp
+    wget -qO - "https://archive.ubuntu.com/ubuntu/pool/main/b/busybox/busybox_${BUSYBOX_RELEASE}.orig.tar.bz2" | tar -xj
+    wget -qO - "https://archive.ubuntu.com/ubuntu/pool/main/b/busybox/busybox_${BUSYBOX_RELEASE}-${BUSYBOX_REV}ubuntu1.debian.tar.xz" | tar -xJ -C busybox-${BUSYBOX_RELEASE}
+
+    cd busybox-${BUSYBOX_RELEASE}
+
+    for f in CVE-2024-58251-2.patch CVE-2025-46394.patch; do
+      wget -q -P debian/patches https://raw.githubusercontent.com/wolfi-dev/os/050b3a5b2846b85cb385aa72cabbd457964a42a6/busybox/${f}
+      echo ${f} >> debian/patches/series
+    done
+
+    if [ -f debian/patches/series ]; then \
+        while read p; do \
+            [ -z "$p" ] && continue; \
+            echo "Applying patch: $p"; \
+            patch -p1 < "debian/patches/$p"; \
+        done < debian/patches/series; \
+    fi
+
+    cp debian/config/pkg/deb .config
+    make oldconfig
+    make -j"$(nproc)"
+    make CONFIG_PREFIX=/root-fs install
+    /root-fs/bin/busybox --install /root-fs/bin
+
     wget -qO - "https://github.com/ncopa/su-exec/archive/refs/tags/v${SUEXEC_RELEASE}.tar.gz" | tar -xz -C /tmp && make -C /tmp/su-exec-${SUEXEC_RELEASE} && mv /tmp/su-exec-${SUEXEC_RELEASE}/su-exec /root-fs/sbin/su-exec
+EOF
 
 FROM scratch
 


### PR DESCRIPTION
This change updates Chisel (v1.2.0) and BusyBox (v1.37.0) and manually patches CVE's for BusyBox.
The Dockerfile has been adapted to the Heredocs style and Probot triggers updated.