### PR TITLE
fix: busybox for arm64

### DIFF
--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -34,11 +34,12 @@ fi
 cat << EOF
     agents:
       upload: "fast"
-
-  - wait
+    key: "build-docker-linux"
 
   - label: ":docker: Update README.md"
     command: "curl \"https://ci.nerv.com.au/readmesync/update?github_repo=${REPOSITORY}&dockerhub_repo=${REPOSITORY//image}\""
+    depends_on:
+      - "build-docker-linux"
     agents:
       upload: "fast"
     if: build.branch == "master"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM buildpack-deps:24.04 AS chisel
 
-ARG BUSYBOX_RELEASE=1.37.0
-ARG BUSYBOX_REV=4
 ARG CHISEL_RELEASE="1.2.0"
 ARG SUEXEC_RELEASE="0.2"
 ARG TARGETARCH
@@ -14,6 +12,20 @@ RUN <<EOF
     chisel cut --release ubuntu-24.04 --root /root-fs \
     base-files_base base-files_release-info base-passwd_data \
     ca-certificates_data libc-bin_nsswitch tzdata_zoneinfo wget_bins && \
+
+    wget -qO - "https://github.com/ncopa/su-exec/archive/refs/tags/v${SUEXEC_RELEASE}.tar.gz" | tar -xz -C /tmp && make -C /tmp/su-exec-${SUEXEC_RELEASE} && mv /tmp/su-exec-${SUEXEC_RELEASE}/su-exec /root-fs/sbin/su-exec
+EOF
+
+FROM --platform=${BUILDPLATFORM} authelia/crossbuild AS crossbuild
+
+ARG BUSYBOX_RELEASE=1.37.0
+ARG BUSYBOX_REV=4
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-c"]
+
+RUN <<EOF
+    set -euo pipefail
 
     cd /tmp
     wget -qO - "https://archive.ubuntu.com/ubuntu/pool/main/b/busybox/busybox_${BUSYBOX_RELEASE}.orig.tar.bz2" | tar -xj
@@ -29,20 +41,33 @@ RUN <<EOF
     if [ -f debian/patches/series ]; then \
         while read p; do \
             [ -z "$p" ] && continue; \
+            [[ "$p" == \#* ]] && continue; \
             echo "Applying patch: $p"; \
             patch -p1 < "debian/patches/$p"; \
         done < debian/patches/series; \
+    fi
+
+    if [[ ${TARGETARCH} == "arm" ]]; then
+      export CROSS_COMPILE=arm-linux-gnueabihf-
+    elif [[ ${TARGETARCH} == "arm64" ]]; then
+      export CROSS_COMPILE=aarch64-linux-gnu-
     fi
 
     cp debian/config/pkg/deb .config
     make oldconfig
     make -j"$(nproc)"
     make CONFIG_PREFIX=/root-fs install
-    /root-fs/bin/busybox --install /root-fs/bin
+EOF
 
-    wget -qO - "https://github.com/ncopa/su-exec/archive/refs/tags/v${SUEXEC_RELEASE}.tar.gz" | tar -xz -C /tmp && make -C /tmp/su-exec-${SUEXEC_RELEASE} && mv /tmp/su-exec-${SUEXEC_RELEASE}/su-exec /root-fs/sbin/su-exec
+FROM buildpack-deps:24.04 AS final
+
+COPY --link --from=chisel /root-fs /root-fs
+COPY --link --from=crossbuild /root-fs/bin/busybox /root-fs/bin/busybox
+
+RUN <<EOF
+    /root-fs/bin/busybox --install /root-fs/bin
 EOF
 
 FROM scratch
 
-COPY --link --from=chisel /root-fs /
+COPY --link --from=final /root-fs /

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This container includes the bare minimum packages for Authelia to function in a 
 * wget
 
 ## Version
+- **02/10/2025:** Cross-compile BusyBox in authelia/crossbuild
 - **28/10/2024:** Swap to musl-static variant of su-exec for multi-arch support
 - **16/10/2024:** Add Provenance and SBOM attestations
 - **15/10/2024:** Initial release


### PR DESCRIPTION
This change uses `authelia/crossbuild` to cross-compile BusyBox instead of natively compiling with QEMU. To resolve a compiling issue for arm64.